### PR TITLE
Expand `time` and constrain `base`

### DIFF
--- a/canteven-parsedate.cabal
+++ b/canteven-parsedate.cabal
@@ -19,9 +19,9 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:
-    base,
+    base >=4.7 && <4.9,
     old-locale,
-    time >=1.5 && < 1.6,
+    time >=1.4.2 && < 1.6,
     timezone-series,
     tz
   hs-source-dirs:      src
@@ -38,7 +38,7 @@ Test-Suite test-parsedate
     base,
     canteven-parsedate,
     old-locale,
-    time >=1.5 && < 1.6,
+    time >=1.4.2 && < 1.6,
     timezone-series,
     tz
   default-language:    Haskell2010

--- a/canteven-parsedate.cabal
+++ b/canteven-parsedate.cabal
@@ -1,5 +1,5 @@
 name:                canteven-parsedate
-version:             1.0.1.0
+version:             1.0.1.1
 synopsis:            Date / time parsing utilities that try to guess the date / time format.
 -- description:         
 license:             Apache-2.0


### PR DESCRIPTION
Base needs to be bounded (on the upper level, at least).
And time was being bounded to 1.5 on the lower lvl (this made it
incompatible with ghc-7.8)