### PR TITLE
Constrain time's dependency again

### DIFF
--- a/canteven-parsedate.cabal
+++ b/canteven-parsedate.cabal
@@ -1,5 +1,5 @@
 name:                canteven-parsedate
-version:             1.0.1.1
+version:             1.0.1.2
 synopsis:            Date / time parsing utilities that try to guess the date / time format.
 -- description:         
 license:             Apache-2.0
@@ -20,8 +20,7 @@ library
   -- other-extensions:    
   build-depends:
     base >=4.7 && <4.9,
-    old-locale,
-    time >=1.4.2 && < 1.6,
+    time >=1.5 && < 1.6,
     timezone-series,
     tz
   hs-source-dirs:      src


### PR DESCRIPTION
Relaxing the lower bound was a mistake.